### PR TITLE
Add support for injected loggers (for #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ meteor add percolate:synced-cron
 
 ### Basics
 
-To write a cron job, give it a unique name, a schedule an a function to run like below. SyncedCron uses the fantastic [later.js](http://bunkat.github.io/later/) library behind the scenes. A Later.js `parse` object is passed into the schedule call that gives you a huge amount of flexibility for scheduling your jobs, see the [documentation](http://bunkat.github.io/later/parsers.html#overview). 
+To write a cron job, give it a unique name, a schedule an a function to run like below. SyncedCron uses the fantastic [later.js](http://bunkat.github.io/later/) library behind the scenes. A Later.js `parse` object is passed into the schedule call that gives you a huge amount of flexibility for scheduling your jobs, see the [documentation](http://bunkat.github.io/later/parsers.html#overview).
 
 ``` js
 SyncedCron.add({
@@ -20,7 +20,7 @@ SyncedCron.add({
   schedule: function(parser) {
     // parser is a later.parse object
     return parser.text('every 2 hours');
-  }, 
+  },
   job: function() {
     var numbersCrunched = CrushSomeNumbers();
     return numbersCrunched;
@@ -57,31 +57,64 @@ Call `SyncedCron.stop()` to remove and stop all jobs.
 
 ### Configuration
 
-Modify the object `SyncedCron.options` to set configuration entries. Defaults are: 
+You can configure SyncedCron with the `config` method. Defaults are:
 
 ``` js
-  SyncedCron.options = {
-    //Log job run details to console
+  SyncedCron.config({
+    // Log job run details to console
     log: true,
 
-    //Name of collection to use for synchronisation and logging
+    // Use a custom logger function (defaults to Meteor's logging package)
+    logger: null
+
+    // Name of collection to use for synchronisation and logging
     collectionName: 'cronHistory',
 
-    //Default to using localTime
-    utc: false, 
+    // Default to using localTime
+    utc: false,
 
-    //TTL in seconds for history records in collection to expire
-    //NOTE: Unset to remove expiry but ensure you remove the index from 
-    //mongo by hand
-    //
-    //ALSO: SyncedCron can't use the `_ensureIndex` command to modify 
-    //the TTL index. The best way to modify the default value of 
-    //`collectionTTL` is to remove the index by hand (in the mongo shell 
-    //run `db.cronHistory.dropIndex({startedAt: 1})`) and re-run your 
-    //project. SyncedCron will recreate the index with the updated TTL.
+    /*
+      TTL in seconds for history records in collection to expire
+      NOTE: Unset to remove expiry but ensure you remove the index from
+      mongo by hand
+
+      ALSO: SyncedCron can't use the `_ensureIndex` command to modify
+      the TTL index. The best way to modify the default value of
+      `collectionTTL` is to remove the index by hand (in the mongo shell
+      run `db.cronHistory.dropIndex({startedAt: 1})`) and re-run your
+      project. SyncedCron will recreate the index with the updated TTL.
+    */
     collectionTTL: 172800
-  }
+  });
 ```
+
+### Logging
+
+SyncedCron uses Meteor's `logging` package by default. If you want to use your own logger (for sending to other consumers or similar) you can do so by configuring the `logger` option.
+
+SyncedCron expects a function as `logger`, and will pass arguments to it for you to take action on.
+
+```js
+var MyLogger = function(opts) {
+  console.log('Level', opts.level);
+  console.log('Message', opts.message);
+  console.log('Tag', opts.tag);
+}
+
+SyncedCron.config({
+  logger: MyLogger
+});
+
+SyncedCron.add({ name: 'Test Job', ... });
+SyncedCron.start();
+```
+
+The `opts` object passed to `MyLogger` above includes `level`, `message`, and `tag`.
+
+- `level` will be one of `info`, `warn`, `error`, `debug`.
+- `message` is something like `Scheduled "Test Job" next run @Fri Mar 13 2015 10:15:00 GMT+0100 (CET)`.
+- `tag` will always be `"SyncedCron"` (handy for filtering).
+
 
 ## Caveats
 
@@ -95,7 +128,7 @@ Write some code. Write some tests. To run the tests, do:
 $ meteor test-packages ./
 ```
 
-## License 
+## License
 
 MIT. (c) Percolate Studio
 

--- a/package.js
+++ b/package.js
@@ -15,6 +15,6 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['percolatestudio:synced-cron', 'tinytest']);
+  api.use(['percolate:synced-cron', 'tinytest']);
   api.add_files('synced-cron-tests.js', ['server']);
 });

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -16,6 +16,9 @@ SyncedCron = {
     //NOTE: Unset to remove expiry but ensure you remove the index from
     //mongo by hand
     collectionTTL: 172800
+  },
+  config: function(opts) {
+    this.options = _.extend({}, this.options, opts);
   }
 }
 

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -37,20 +37,19 @@ Later = Npm.require('later');
     level: String (info, warn, error, debug)
     tag: 'SyncedCron'
 */
-function createLogger(prefix, options) {
+function createLogger(prefix) {
   check(prefix, String);
-  check(options, Match.Optional(Object))
-
-  var logger = options && options.logger;
 
   // Return noop if logging is disabled.
-  if(options.log === false) {
+  if(SyncedCron.options.log === false) {
     return function() {};
   }
 
   return function(level, message) {
     check(level, Match.OneOf('info', 'error', 'warn', 'debug'));
     check(message, String);
+
+    var logger = SyncedCron.options && SyncedCron.options.logger;
 
     if(logger && _.isFunction(logger)) {
 
@@ -71,7 +70,7 @@ var log;
 Meteor.startup(function() {
   var options = SyncedCron.options;
 
-  log = createLogger('SyncedCron', options);
+  log = createLogger('SyncedCron');
 
   ['info', 'warn', 'error', 'debug'].forEach(function(level) {
     log[level] = _.partial(log, level);

--- a/synced-cron-tests.js
+++ b/synced-cron-tests.js
@@ -131,3 +131,20 @@ Tinytest.add('SyncedCron.add starts by it self when running', function(test) {
   test.equal(SyncedCron.running, false);
   test.equal(_.keys(SyncedCron._entries).length, 0);
 });
+
+Tinytest.add('SyncedCron.config can customize the options object', function(test) {
+  SyncedCron._reset();
+
+  SyncedCron.config({
+    log: false,
+    collectionName: 'foo',
+    utc: true,
+    collectionTTL: 0
+  });
+
+  test.equal(SyncedCron.options.log, false);
+  test.equal(SyncedCron.options.collectionName, 'foo');
+  test.equal(SyncedCron.options.utc, true);
+  test.equal(SyncedCron.options.collectionTTL, 0);
+});
+

--- a/synced-cron-tests.js
+++ b/synced-cron-tests.js
@@ -148,3 +148,38 @@ Tinytest.add('SyncedCron.config can customize the options object', function(test
   test.equal(SyncedCron.options.collectionTTL, 0);
 });
 
+Tinytest.addAsync('SyncedCron can log to injected logger', function(test, done) {
+  SyncedCron._reset();
+
+  var logger = function() {
+    test.isTrue(true);
+    done();
+  };
+
+  SyncedCron.options.logger = logger;
+
+  SyncedCron.add(TestEntry);
+  SyncedCron.start();
+
+  SyncedCron.options.logger = null;
+});
+
+Tinytest.addAsync('SyncedCron should pass correct arguments to logger', function(test, done) {
+  SyncedCron._reset();
+
+  var logger = function(opts) {
+    test.include(opts, 'level');
+    test.include(opts, 'message');
+    test.include(opts, 'tag');
+    test.equal(opts.tag, 'SyncedCron');
+    
+    done();
+  };
+
+  SyncedCron.options.logger = logger;
+
+  SyncedCron.add(TestEntry);
+  SyncedCron.start();
+
+  SyncedCron.options.logger = null;
+});


### PR DESCRIPTION
This patch for #43 adds ability to use an external logger in the `options.logger` property. `SyncedCron` still defaults to Meteor's `logging` package.

I also took the liberty of adding a `config` method to `SyncedCron`, in order for users to accidentally overwrite the whole `options` object with defaults.

The injected logger should be a *function* which takes an *object*:

```js
MyLogger = function(opts) {
   console.log(opts.level);
   console.log(opts.tag + ': ' + opts.message);
};

SyncedCron.config({
   logger: MyLogger
});

SyncedCron.add(/* ... */);
SyncedCron.start();
```

The `opts` object passed to the logger consists of:

- `level` - `info`, `warn`, `error`, `debug`.
- `message`- The message.
- `tag` - `SyncedCron`, for having as a filter, or similar.

This way users can tailor their logger function to send logs any other output if they'd like.

What I couldn't solve was tests. I wanted something like this:

```js
Tinytest.add('SyncedCron can log to injected logger', function(test) {
  SyncedCron._reset();
  var called = false;

  // Simple spy.
  var logger = function() {
    called = true;
  }

  SyncedCron.options.logger = logger;

  SyncedCron.add(TestEntry);
  SyncedCron.start();

  test.equal(called, true);  // SyncedCron.options.logger is still null here.
  SyncedCron.options.logger = null;
});
```

Thoughts? I think it is the fact that much of the logic in the package is in a `Meteor.startup` wrapper. Is TinyTest waiting for all `Meteor.startup` routines to run? The logger relies on the internal startup to run, and thus the test might "run too fast".