### PR TITLE
added pause method and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Call `SyncedCron.remove(jobName)` to remove and stop running the job referenced 
 
 Call `SyncedCron.stop()` to remove and stop all jobs.
 
+Call `SyncedCron.pause()` to stop all jobs without removing them.  The existing jobs can be rescheduled (i.e. restarted) with `SyncedCron.start()`.
+
 ### Configuration
 
 You can configure SyncedCron with the `config` method. Defaults are:

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Allows you to define and run scheduled jobs across multiple servers.",
-  version: "1.2.0",
+  version: "1.2.1",
   name: "percolate:synced-cron",
   git: "https://github.com/percolatestudio/meteor-synced-cron.git"
 });

--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -163,6 +163,17 @@ SyncedCron.remove = function(jobName) {
   }
 }
 
+// Pause processing, but do not remove jobs so that the start method will
+// restart existing jobs
+SyncedCron.pause = function() {
+  if (this.running) {
+    _.each(this._entries, function(entry) {
+      entry._timer.clear();
+    });
+    this.running = false;
+  }
+}
+
 // Stop processing and remove ALL jobs
 SyncedCron.stop = function() {
   _.each(this._entries, function(entry, name) {

--- a/synced-cron-tests.js
+++ b/synced-cron-tests.js
@@ -106,6 +106,37 @@ Tinytest.add('SyncedCron.stop works', function(test) {
   test.equal(_.keys(SyncedCron._entries).length, 0);
 });
 
+Tinytest.add('SyncedCron.pause works', function(test) {
+  SyncedCron._reset();
+  test.equal(SyncedCron._collection.find().count(), 0);
+
+  // addd 2 entries
+  SyncedCron.add(TestEntry);
+
+  var entry2 = _.extend({}, TestEntry, {
+    name: 'Test Job2',
+    schedule: function(parser) {
+      return parser.cron('30 11 * * ? *');
+    }
+  });
+  SyncedCron.add(entry2);
+
+  SyncedCron.start();
+
+  test.equal(_.keys(SyncedCron._entries).length, 2);
+
+  SyncedCron.pause();
+
+  test.equal(_.keys(SyncedCron._entries).length, 2);
+  test.isFalse(SyncedCron.running);
+
+  SyncedCron.start();
+
+  test.equal(_.keys(SyncedCron._entries).length, 2);
+  test.isTrue(SyncedCron.running);
+
+});
+
 // Tests SyncedCron.remove in the process
 Tinytest.add('SyncedCron.add starts by it self when running', function(test) {
   SyncedCron._reset();
@@ -172,7 +203,7 @@ Tinytest.addAsync('SyncedCron should pass correct arguments to logger', function
     test.include(opts, 'message');
     test.include(opts, 'tag');
     test.equal(opts.tag, 'SyncedCron');
-    
+
     done();
   };
 


### PR DESCRIPTION
Added a `pause` method, which clears all existing timers, but leaves `_entries` populated, so that jobs can be rescheduled with the `start` method.

Simple tests included to ensure the cron is stopped and started as expected and original jobs retained.