### PR TITLE
Discard milliseconds from intendedAt

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -188,6 +188,9 @@ SyncedCron._entryWrapper = function(entry) {
   var self = this;
 
   return function(intendedAt) {
+    intendedAt = new Date(intendedAt.getTime());
+    intendedAt.setMilliseconds(0);
+
     var jobHistory = {
       intendedAt: intendedAt,
       name: entry.name,


### PR DESCRIPTION
Later.js can return milliseconds for next(), these are of course not the same on every instance, therefore the unique index on name, intendedAt won't work and jobs will run multiple times.

Check out the following example:
```js
var cron = later.parse.cron('* * * * *');
var nextCron = later.schedule(cron).next(1);
console.log(nextCron.toISOString());
```
It returns '2015-08-31T15:52:00.869Z'.

This patch removes the milliseconds from intendedAt before it get saved to the database.
