### PR TITLE
Access to  job name when running the actual job

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -215,7 +215,7 @@ SyncedCron._entryWrapper = function(entry) {
     // run and record the job
     try {
       log.info('Starting "' + entry.name + '".');
-      var output = entry.job(intendedAt); // <- Run the actual job
+      var output = entry.job(intendedAt,entry.name); // <- Run the actual job
 
       log.info('Finished "' + entry.name + '".');
       self._collection.update({_id: jobHistory._id}, {


### PR DESCRIPTION
passing name of job when running the actual job for added flexibility

```javascript
SyncedCron.add({
        name: 'your job',
        schedule: function(parser) {
            // parser is a later.parse object
            return parser.recur().on('11:22:00').time();
        },
        job: function(intendentAt, jobName) {
           console.log('oya! boss  '+jobName+' is being done at '+intendentAt.toString());
        }
    });
```