### PR TITLE
Fixed rescheduling jobs when mongodb timed out during execution of job.

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -225,11 +225,11 @@ SyncedCron._entryWrapper = function(entry) {
         }
       });
     } catch(e) {
-      log.info('Exception "' + entry.name +'" ' + e.stack);
+      log.info('Exception "' + entry.name +'" ' + ((e && e.stack) ? e.stack : e));
       self._collection.update({_id: jobHistory._id}, {
         $set: {
           finishedAt: new Date(),
-          error: e.stack
+          error: (e && e.stack) ? e.stack : e
         }
       });
     }
@@ -263,7 +263,12 @@ SyncedCron._laterSetInterval = function(fn, sched) {
   */
   function scheduleTimeout(intendedAt) {
     if(!done) {
-      fn(intendedAt);
+      try {
+        fn(intendedAt);
+      } catch(e) {
+        log.info('Exception running scheduled job ' + ((e && e.stack) ? e.stack : e));
+      }
+
       t = SyncedCron._laterSetTimeout(scheduleTimeout, sched);
     }
   }


### PR DESCRIPTION
When using external mongo db, if it timedout when running a scheduled job or when trying to update a job that has thrown an exception, the job would not be rescheduled to run again.
This fixes that.
