### PR TITLE
Fix for #134

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -212,7 +212,7 @@ SyncedCron._entryWrapper = function(entry) {
       } catch(e) {
         // http://www.mongodb.org/about/contributors/error-codes/
         // 11000 == duplicate key error
-        if (e.name === 'MongoError' && e.code === 11000) {
+        if (e.code === 11000) {
           log.info('Not running "' + entry.name + '" again.');
           return;
         }


### PR DESCRIPTION
Fixes https://github.com/percolatestudio/meteor-synced-cron/issues/134

Fix error handling for Meteor 1.7.

Meteor 1.7 uses v3 of the Mongo driver, which changes
the errors thrown by bulk operations.  Meteor uses .insert()
rather than .insertOne(), so is affected.  As a result, with
Meteor 1.7, the error's name is BulkWriteError, not MongoError.

This commit makes the check compatible with both v2 and v3 of the
Mongo driver, by checking just the error code, not the name.