### PR TITLE
Blocks a job from running if the previous job hasn't finished

### DIFF
--- a/synced-cron-server.js
+++ b/synced-cron-server.js
@@ -199,6 +199,14 @@ SyncedCron._entryWrapper = function(entry) {
     var jobHistory;
 
     if (entry.persist) {
+      
+      // Wait for previous job to finish
+      let previousRunningJob = self._collection.findOne({"name": entry.name, "finishedAt": {$exists: false}}, {sort: {intendedAt: -1}});
+      if(previousRunningJob){
+        log.info('Previous "' + entry.name + '" job not finished.');
+        return;
+      }
+      
       jobHistory = {
         intendedAt: intendedAt,
         name: entry.name,


### PR DESCRIPTION
In a multi server environment, if a job hasn't finished, another job can start running causing a race condition.

This is noticeable on jobs that run every few seconds and don't finish in time.